### PR TITLE
Add layer norm as an option to model

### DIFF
--- a/3rd_party/gnn/conf/config.yaml
+++ b/3rd_party/gnn/conf/config.yaml
@@ -33,6 +33,7 @@ lr_phase23: 0.0001
 hidden_channels: 32
 n_mlp_hidden_layers: 5
 n_messagePassing_layers: 4
+layer_norm: False
 
 # Halo swap mode 
 halo_swap_mode : none

--- a/3rd_party/gnn/gnn.py
+++ b/3rd_party/gnn/gnn.py
@@ -33,17 +33,13 @@ class DistributedGNN(torch.nn.Module):
         self.layer_norm = layer_norm
         self.name = name
 
-        # ~~~~ set the norm layer if requested
-        if self.layer_norm:
-            norm_layer = torch.nn.LayerNorm(self.hidden_channels)
-
         # ~~~~ node encoder MLP
         self.node_encoder = MLP(
                 input_channels = self.input_node_channels,
                 hidden_channels = [self.hidden_channels]*(self.n_mlp_hidden_layers+1),
                 output_channels = self.hidden_channels,
                 activation_layer = torch.nn.ELU(),
-                norm_layer = norm_layer
+                norm_layer = torch.nn.LayerNorm(self.hidden_channels) if self.layer_norm else None
                 )
 
         # ~~~~ edge encoder MLP
@@ -52,7 +48,7 @@ class DistributedGNN(torch.nn.Module):
                 hidden_channels = [self.hidden_channels]*(self.n_mlp_hidden_layers+1),
                 output_channels = self.hidden_channels,
                 activation_layer = torch.nn.ELU(),
-                norm_layer = norm_layer
+                norm_layer = torch.nn.LayerNorm(self.hidden_channels) if self.layer_norm else None
                 )
 
         # ~~~~ node decoder MLP
@@ -71,6 +67,7 @@ class DistributedGNN(torch.nn.Module):
                                      channels = self.hidden_channels,
                                      n_mlp_hidden_layers = self.n_mlp_hidden_layers,
                                      halo_swap_mode = self.halo_swap_mode, 
+                                     layer_norm = self.layer_norm
                                      )
                                   )
 
@@ -350,17 +347,13 @@ class DistributedMessagePassingLayer(torch.nn.Module):
         self.halo_swap_mode = halo_swap_mode
         self.layer_norm = layer_norm
 
-        # ~~~~ set the norm layer if requested
-        if self.layer_norm:
-            norm_layer = torch.nn.LayerNorm(self.hidden_channels)
-
         # Edge update MLP 
         self.edge_updater = MLP(
                 input_channels = self.channels*3,
                 hidden_channels = [self.channels]*(self.n_mlp_hidden_layers+1),
                 output_channels = self.channels,
                 activation_layer = torch.nn.ELU(),
-                norm_layer = norm_layer
+                norm_layer = torch.nn.LayerNorm(self.channels) if self.layer_norm else None
                 )
 
         # Node update MLP
@@ -369,7 +362,7 @@ class DistributedMessagePassingLayer(torch.nn.Module):
                 hidden_channels = [self.channels]*(self.n_mlp_hidden_layers+1),
                 output_channels = self.channels,
                 activation_layer = torch.nn.ELU(),
-                norm_layer = norm_layer
+                norm_layer = torch.nn.LayerNorm(self.channels) if self.layer_norm else None
                 )
 
         self.reset_parameters()

--- a/3rd_party/gnn/trainer.py
+++ b/3rd_party/gnn/trainer.py
@@ -332,6 +332,7 @@ class Trainer:
         n_mlp_hidden_layers = self.cfg.n_mlp_hidden_layers
         n_messagePassing_layers = self.cfg.n_messagePassing_layers
         halo_swap_mode = self.cfg.halo_swap_mode
+        layer_norm = self.cfg.layer_norm
         #name = 'POLY_%d_RANK_%d_SIZE_%d_SEED_%d' %(poly,RANK,SIZE,self.cfg.seed)
         name = 'POLY_%d_SIZE_%d_SEED_%d' %(poly,SIZE,self.cfg.seed)
         if self.cfg.use_residual:
@@ -344,6 +345,7 @@ class Trainer:
                            n_mlp_hidden_layers,
                            n_messagePassing_layers,
                            halo_swap_mode,
+                           layer_norm,
                            name)
         return model
 

--- a/examples/tgv_gnn_offline/clean
+++ b/examples/tgv_gnn_offline/clean
@@ -1,4 +1,5 @@
 #!/bin/bash
 
-rm -r gnn_outputs_poly_3 outputs _pyg ckpt/ saved_models/
+rm -rf _pyg
+rm -r gnn_outputs_poly_3 outputs ckpt/ saved_models/
 rm run.sh

--- a/examples/tgv_gnn_offline/nrsrun_aurora
+++ b/examples/tgv_gnn_offline/nrsrun_aurora
@@ -78,6 +78,6 @@ echo "echo \"Checking GNN graph input files ...\"" >>$RFILE
 echo "python ${NEKRS_HOME}/3rd_party/gnn/check_input_files.py --REF ./ref --PATH ./gnn_outputs_poly_3" >>$RFILE
 
 echo -e "\n# Train the GNN" >>$RFILE
-echo "mpiexec -n ${TOTAL_RANKS} -ppn ${RANKS_PER_NODE} --cpu-bind=list:${CPU_BIND_LIST} python ${NEKRS_HOME}/3rd_party/gnn/main.py backend=ccl halo_swap_mode=all_to_all_opt gnn_outputs_path=${PWD}/gnn_outputs_poly_3 target_loss=1.6206e-04" >> $RFILE
+echo "mpiexec -n ${TOTAL_RANKS} -ppn ${RANKS_PER_NODE} --cpu-bind=list:${CPU_BIND_LIST} python ${NEKRS_HOME}/3rd_party/gnn/main.py backend=ccl halo_swap_mode=all_to_all_opt layer_norm=True gnn_outputs_path=${PWD}/gnn_outputs_poly_3 target_loss=1.6206e-04" >> $RFILE
 chmod u+x $RFILE
 

--- a/examples/tgv_gnn_offline/nrsrun_polaris
+++ b/examples/tgv_gnn_offline/nrsrun_polaris
@@ -54,6 +54,6 @@ echo "echo \"Checking GNN graph input files ...\"" >>$RFILE
 echo "python ${NEKRS_HOME}/3rd_party/gnn/check_input_files.py --REF ./ref --PATH ./gnn_outputs_poly_3" >>$RFILE
 
 echo -e "\n# Train the GNN" >>$RFILE
-echo "mpiexec -n ${TOTAL_RANKS} -ppn ${RANKS_PER_NODE} --cpu-bind=list:${CPU_BIND_LIST} python ${NEKRS_HOME}/3rd_party/gnn/main.py backend=nccl halo_swap_mode=all_to_all_opt gnn_outputs_path=${PWD}/gnn_outputs_poly_3 target_loss=1.6206e-04" >> $RFILE
+echo "mpiexec -n ${TOTAL_RANKS} -ppn ${RANKS_PER_NODE} --cpu-bind=list:${CPU_BIND_LIST} python ${NEKRS_HOME}/3rd_party/gnn/main.py backend=nccl halo_swap_mode=all_to_all_opt layer_norm=True gnn_outputs_path=${PWD}/gnn_outputs_poly_3 target_loss=1.6206e-04" >> $RFILE
 chmod u+x $RFILE
 

--- a/examples/tgv_gnn_online/nrsrun_aurora
+++ b/examples/tgv_gnn_online/nrsrun_aurora
@@ -136,9 +136,9 @@ echo "    executable: \"${NEKRS_HOME}/3rd_party/gnn/main.py\"" >> $CFILE
 #echo "    affinity: \"./${TAFF_FILE}\"" >> $CFILE
 echo "    affinity: \"\"" >> $CFILE
 if [ ${DEPLOYMENT} == "colocated"  ]; then
-  echo "    arguments: \"device_skip=${SIM_RANKS_PER_NODE} backend=ccl halo_swap_mode=all_to_all_opt online=True client.db_nodes=${DB_NODES} consistency=True target_loss=1.6206e-04 verbose=True\"" >> $CFILE
+  echo "    arguments: \"device_skip=${SIM_RANKS_PER_NODE} backend=ccl halo_swap_mode=all_to_all_opt layer_norm=True online=True client.db_nodes=${DB_NODES} consistency=True target_loss=1.6206e-04 verbose=True\"" >> $CFILE
 elif [ ${DEPLOYMENT} == "clustered"  ]; then
-  echo "    arguments: \"backend=ccl halo_swap_mode=all_to_all_opt online=True client.db_nodes=${DB_NODES} consistency=True target_loss=1.6206e-04 verbose=True\"" >> $CFILE
+  echo "    arguments: \"backend=ccl halo_swap_mode=all_to_all_opt layer_norm=True online=True client.db_nodes=${DB_NODES} consistency=True target_loss=1.6206e-04 verbose=True\"" >> $CFILE
 fi
 echo "    copy_files: []" >> $CFILE
 echo "    link_files: [\"./${TAFF_FILE}\"]" >> $CFILE

--- a/examples/tgv_gnn_online/nrsrun_polaris
+++ b/examples/tgv_gnn_online/nrsrun_polaris
@@ -111,9 +111,9 @@ echo "    executable: \"${NEKRS_HOME}/3rd_party/gnn/main.py\"" >> $CFILE
 #echo "    affinity: \"./${TAFF_FILE}\"" >> $CFILE
 echo "    affinity: \"\"" >> $CFILE
 if [ ${DEPLOYMENT} == "colocated"  ]; then
-  echo "    arguments: \"device_skip=${SIM_RANKS_PER_NODE} backend=nccl halo_swap_mode=all_to_all_opt online=True client.db_nodes=${DB_NODES} consistency=True target_loss=1.6206e-04 verbose=True\"" >> $CFILE
+  echo "    arguments: \"device_skip=${SIM_RANKS_PER_NODE} backend=nccl halo_swap_mode=all_to_all_opt layer_norm=True online=True client.db_nodes=${DB_NODES} consistency=True target_loss=1.6206e-04 verbose=True\"" >> $CFILE
 elif [ ${DEPLOYMENT} == "clustered"  ]; then
-  echo "    arguments: \"backend=nccl halo_swap_mode=all_to_all_opt online=True client.db_nodes=${DB_NODES} consistency=True target_loss=1.6206e-04 verbose=True\"" >> $CFILE
+  echo "    arguments: \"backend=nccl halo_swap_mode=all_to_all_opt layer_norm=True online=True client.db_nodes=${DB_NODES} consistency=True target_loss=1.6206e-04 verbose=True\"" >> $CFILE
 fi
 echo "    copy_files: []" >> $CFILE
 echo "    link_files: [\"./${TAFF_FILE}\"]" >> $CFILE

--- a/examples/tgv_gnn_traj_offline/nrsrun_aurora
+++ b/examples/tgv_gnn_traj_offline/nrsrun_aurora
@@ -84,6 +84,6 @@ echo "  python ${NEKRS_HOME}/3rd_party/gnn/check_input_files.py --REF ./ref/traj
 echo "done" >>$RFILE
 
 echo -e "\n# Train the GNN" >>$RFILE
-echo "mpiexec -n ${TOTAL_RANKS} -ppn ${RANKS_PER_NODE} --cpu-bind=list:${CPU_BIND_LIST} python ${NEKRS_HOME}/3rd_party/gnn/main.py backend=ccl halo_swap_mode=all_to_all_opt gnn_outputs_path=${PWD}/gnn_outputs_poly_7 traj_data_path=${PWD}/traj_poly_7/tinit_0.000000_dtfactor_10 time_dependency=time_dependent target_loss=6.9076e-01" >> $RFILE
+echo "mpiexec -n ${TOTAL_RANKS} -ppn ${RANKS_PER_NODE} --cpu-bind=list:${CPU_BIND_LIST} python ${NEKRS_HOME}/3rd_party/gnn/main.py backend=ccl halo_swap_mode=all_to_all_opt layer_norm=True gnn_outputs_path=${PWD}/gnn_outputs_poly_7 traj_data_path=${PWD}/traj_poly_7/tinit_0.000000_dtfactor_10 time_dependency=time_dependent target_loss=6.9076e-01" >> $RFILE
 chmod u+x $RFILE
 

--- a/examples/tgv_gnn_traj_offline/nrsrun_polaris
+++ b/examples/tgv_gnn_traj_offline/nrsrun_polaris
@@ -60,6 +60,6 @@ echo "  python ${NEKRS_HOME}/3rd_party/gnn/check_input_files.py --REF ./ref/traj
 echo "done" >>$RFILE
 
 echo -e "\n# Train the GNN" >>$RFILE
-echo "mpiexec -n ${TOTAL_RANKS} -ppn ${RANKS_PER_NODE} --cpu-bind=list:${CPU_BIND_LIST} python ${NEKRS_HOME}/3rd_party/gnn/main.py backend=nccl halo_swap_mode=all_to_all_opt gnn_outputs_path=${PWD}/gnn_outputs_poly_7 traj_data_path=${PWD}/traj_poly_7/tinit_0.000000_dtfactor_10 time_dependency=time_dependent target_loss=6.9076e-01" >> $RFILE
+echo "mpiexec -n ${TOTAL_RANKS} -ppn ${RANKS_PER_NODE} --cpu-bind=list:${CPU_BIND_LIST} python ${NEKRS_HOME}/3rd_party/gnn/main.py backend=nccl halo_swap_mode=all_to_all_opt layer_norm=True gnn_outputs_path=${PWD}/gnn_outputs_poly_7 traj_data_path=${PWD}/traj_poly_7/tinit_0.000000_dtfactor_10 time_dependency=time_dependent target_loss=6.9076e-01" >> $RFILE
 chmod u+x $RFILE
 

--- a/examples/tgv_gnn_traj_online/nrsrun_aurora
+++ b/examples/tgv_gnn_traj_online/nrsrun_aurora
@@ -136,9 +136,9 @@ echo "    executable: \"${NEKRS_HOME}/3rd_party/gnn/main.py\"" >> $CFILE
 #echo "    affinity: \"./${TAFF_FILE}\"" >> $CFILE
 echo "    affinity: \"\"" >> $CFILE
 if [ ${DEPLOYMENT} == "colocated"  ]; then
-  echo "    arguments: \"device_skip=${SIM_RANKS_PER_NODE} backend=ccl halo_swap_mode=all_to_all_opt online=True client.db_nodes=${DB_NODES} consistency=True target_loss=6.9076e-01 time_dependency=time_dependent verbose=True\"" >> $CFILE
+  echo "    arguments: \"device_skip=${SIM_RANKS_PER_NODE} backend=ccl halo_swap_mode=all_to_all_opt layer_norm=True online=True client.db_nodes=${DB_NODES} consistency=True target_loss=6.9076e-01 time_dependency=time_dependent verbose=True\"" >> $CFILE
 elif [ ${DEPLOYMENT} == "clustered"  ]; then
-  echo "    arguments: \"backend=ccl halo_swap_mode=all_to_all_opt online=True client.db_nodes=${DB_NODES} consistency=True target_loss=6.9076e-01 time_dependency=time_dependent verbose=True\"" >> $CFILE
+  echo "    arguments: \"backend=ccl halo_swap_mode=all_to_all_opt layer_norm=True online=True client.db_nodes=${DB_NODES} consistency=True target_loss=6.9076e-01 time_dependency=time_dependent verbose=True\"" >> $CFILE
 fi
 echo "    copy_files: []" >> $CFILE
 echo "    link_files: [\"./${TAFF_FILE}\"]" >> $CFILE

--- a/examples/tgv_gnn_traj_online/nrsrun_polaris
+++ b/examples/tgv_gnn_traj_online/nrsrun_polaris
@@ -111,9 +111,9 @@ echo "    executable: \"${NEKRS_HOME}/3rd_party/gnn/main.py\"" >> $CFILE
 #echo "    affinity: \"./${TAFF_FILE}\"" >> $CFILE
 echo "    affinity: \"\"" >> $CFILE
 if [ ${DEPLOYMENT} == "colocated"  ]; then
-  echo "    arguments: \"device_skip=${SIM_RANKS_PER_NODE} backend=nccl halo_swap_mode=all_to_all_opt online=True client.db_nodes=${DB_NODES} consistency=True target_loss=6.9076e-01 time_dependency=time_dependent verbose=True\"" >> $CFILE
+  echo "    arguments: \"device_skip=${SIM_RANKS_PER_NODE} backend=nccl halo_swap_mode=all_to_all_opt layer_norm=True online=True client.db_nodes=${DB_NODES} consistency=True target_loss=6.9076e-01 time_dependency=time_dependent verbose=True\"" >> $CFILE
 elif [ ${DEPLOYMENT} == "clustered"  ]; then
-  echo "    arguments: \"backend=nccl halo_swap_mode=all_to_all_opt online=True client.db_nodes=${DB_NODES} consistency=True target_loss=6.9076e-01 time_dependency=time_dependent verbose=True\"" >> $CFILE
+  echo "    arguments: \"backend=nccl halo_swap_mode=all_to_all_opt layer_norm=True online=True client.db_nodes=${DB_NODES} consistency=True target_loss=6.9076e-01 time_dependency=time_dependent verbose=True\"" >> $CFILE
 fi
 echo "    copy_files: []" >> $CFILE
 echo "    link_files: [\"./${TAFF_FILE}\"]" >> $CFILE

--- a/examples/tgv_gnn_traj_online_adios/nrsrun_aurora
+++ b/examples/tgv_gnn_traj_online_adios/nrsrun_aurora
@@ -121,9 +121,9 @@ echo "    executable: \"${NEKRS_HOME}/3rd_party/gnn/main.py\"" >> $CFILE
 #echo "    affinity: \"./${TAFF_FILE}\"" >> $CFILE
 echo "    affinity: \"\"" >> $CFILE
 if [ ${DEPLOYMENT} == "colocated"  ]; then
-  echo "    arguments: \"device_skip=${SIM_RANKS_PER_NODE} backend=ccl halo_swap_mode=all_to_all_opt hidden_channels=32 n_mlp_hidden_layers=5 n_messagePassing_layers=4 online=True client.backend=adios client.adios_transport=RDMA consistency=True time_dependency=time_dependent target_loss=6.9076e-01 online_update_freq=500 verbose=True\"" >> $CFILE
+  echo "    arguments: \"device_skip=${SIM_RANKS_PER_NODE} backend=ccl halo_swap_mode=all_to_all_opt layer_norm=True hidden_channels=32 n_mlp_hidden_layers=5 n_messagePassing_layers=4 online=True client.backend=adios client.adios_transport=RDMA consistency=True time_dependency=time_dependent target_loss=6.9076e-01 online_update_freq=500 verbose=True\"" >> $CFILE
 elif [ ${DEPLOYMENT} == "clustered"  ]; then
-  echo "    arguments: \"backend=ccl halo_swap_mode=all_to_all_opt hidden_channels=32 n_mlp_hidden_layers=5 n_messagePassing_layers=4 online=True client.backend=adios consistency=True time_dependency=time_dependent target_loss=6.9076e-01 online_update_freq=500 verbose=True\"" >> $CFILE
+  echo "    arguments: \"backend=ccl halo_swap_mode=all_to_all_opt layer_norm=True hidden_channels=32 n_mlp_hidden_layers=5 n_messagePassing_layers=4 online=True client.backend=adios consistency=True time_dependency=time_dependent target_loss=6.9076e-01 online_update_freq=500 verbose=True\"" >> $CFILE
 fi
 
 #--------------------------------------

--- a/examples/tgv_gnn_traj_online_adios/nrsrun_polaris
+++ b/examples/tgv_gnn_traj_online_adios/nrsrun_polaris
@@ -95,9 +95,9 @@ echo "    executable: \"${NEKRS_HOME}/3rd_party/gnn/main.py\"" >> $CFILE
 #echo "    affinity: \"./${TAFF_FILE}\"" >> $CFILE
 echo "    affinity: \"\"" >> $CFILE
 if [ ${DEPLOYMENT} == "colocated"  ]; then
-  echo "    arguments: \"device_skip=${SIM_RANKS_PER_NODE} backend=nccl halo_swap_mode=all_to_all_opt hidden_channels=32 n_mlp_hidden_layers=5 n_messagePassing_layers=4 online=True client.backend=adios client.adios_transport=WAN consistency=True time_dependency=time_dependent target_loss=6.9076e-01 online_update_freq=500 verbose=True\"" >> $CFILE
+  echo "    arguments: \"device_skip=${SIM_RANKS_PER_NODE} backend=nccl halo_swap_mode=all_to_all_opt layer_norm=True hidden_channels=32 n_mlp_hidden_layers=5 n_messagePassing_layers=4 online=True client.backend=adios client.adios_transport=WAN consistency=True time_dependency=time_dependent target_loss=6.9076e-01 online_update_freq=500 verbose=True\"" >> $CFILE
 elif [ ${DEPLOYMENT} == "clustered"  ]; then
-  echo "    arguments: \"backend=nccl halo_swap_mode=all_to_all_opt hidden_channels=32 n_mlp_hidden_layers=5 n_messagePassing_layers=4 online=True client.backend=adios consistency=True time_dependency=time_dependent target_loss=6.9076e-01 online_update_freq=500 verbose=True\"" >> $CFILE
+  echo "    arguments: \"backend=nccl halo_swap_mode=all_to_all_opt layer_norm=True hidden_channels=32 n_mlp_hidden_layers=5 n_messagePassing_layers=4 online=True client.backend=adios consistency=True time_dependency=time_dependent target_loss=6.9076e-01 online_update_freq=500 verbose=True\"" >> $CFILE
 fi
 
 #--------------------------------------


### PR DESCRIPTION
The GNN MLPs take a layer norm as an optional argument. Extend this functionality to the `DistributedGNN` class and add a conflg option to set/unset the layer norm from the MLPs. 

The default for the layer norm config flag is set to False since for larger models it was observed to not provide any accuracy benefit. Currently, this config option applies to node encoder, edge encoder, node updater and edge updater MLPs, not the node decoder MLP, where layer norm was not used. 