### PR TITLE
Fix bindings for persistent colocated DB

### DIFF
--- a/examples/shooting_workflow_adios/nrsrun_aurora
+++ b/examples/shooting_workflow_adios/nrsrun_aurora
@@ -48,7 +48,7 @@ if [ ! -d $NEKRS_HOME/Nek5000 ]; then
   cd $NEKRS_HOME
   git clone https://github.com/rickybalin/Nek5000.git
   cd Nek5000/tools
-  FC=ftn ./maketools genbox
+  FC=`which gfortran` ./maketools genbox
   cd $CWD
 fi
 $NEKRS_HOME/Nek5000/bin/genbox ${1}.box ${1}

--- a/examples/shooting_workflow_smartredis/driver.py
+++ b/examples/shooting_workflow_smartredis/driver.py
@@ -148,7 +148,9 @@ class ShootingWorkflow():
         coDB_manager_settings.set_tasks(self.num_nodes)
         coDB_manager_settings.set_tasks_per_node(1)
         coDB_manager_settings.set_hostlist(self.db_nodes)
-        coDB_manager_settings.set_cpu_binding_type(f"list:{psutil.cpu_count(logical=False)-1}")
+        db_bind = None if self.cfg.run_args.db_cpu_bind=='None' else self.cfg.run_args.db_cpu_bind
+        db_bind_cores = 0 if db_bind is None else len(db_bind)
+        coDB_manager_settings.set_cpu_binding_type(f"list:{psutil.cpu_count(logical=False)-db_bind_cores-1}")
 
         kwargs = {
             'maxclients': 100000,

--- a/examples/shooting_workflow_smartredis/nrsrun_aurora
+++ b/examples/shooting_workflow_smartredis/nrsrun_aurora
@@ -45,7 +45,7 @@ if [ ! -d $NEKRS_HOME/Nek5000 ]; then
   cd $NEKRS_HOME
   git clone https://github.com/rickybalin/Nek5000.git
   cd Nek5000/tools
-  FC=ftn ./maketools genbox
+  FC=`which gfortran` ./maketools genbox
   cd $CWD
 fi
 $NEKRS_HOME/Nek5000/bin/genbox ${1}.box ${1}


### PR DESCRIPTION
Bind persistent colocated DB procs next to DB on last cores of CPU for the `shooting_workflow_smartredis` example.