### PR TITLE
Remove old workaround for DDP on XPU  devices

### DIFF
--- a/3rd_party/gnn/trainer.py
+++ b/3rd_party/gnn/trainer.py
@@ -250,9 +250,7 @@ class Trainer:
 
         # ~~~~ Wrap model in DDP
         if WITH_DDP and SIZE > 1:
-            if WITH_XPU: self.model.to('cpu')
             self.model = DDP(self.model, broadcast_buffers=False, gradient_as_bucket_view=True)
-            if WITH_XPU: self.model.to(self.device)
 
     def checkpoint(self):
         if RANK == 0:


### PR DESCRIPTION
This PR removed an old workaround added to avoid hangs at large scale when calling the DDP wrapper on a model already offloaded to the XPU devices. The workaround would call the DDP wrapper before offloading the model, but this was observed to cause issues with the weights not being the same across all ranks. 

The workaround is no longer needed so it is removed and the DDP wrapper is called on the model offloaded to the XPU devices, which is the recommended approach. 