### PR TITLE
Fix dist-gnn trainer with consistency=False

### DIFF
--- a/3rd_party/dist-gnn/trainer.py
+++ b/3rd_party/dist-gnn/trainer.py
@@ -743,7 +743,7 @@ class Trainer:
             edge_weight = torch.zeros(1, dtype=self.torch_dtype)
             node_degree = torch.zeros(1, dtype=self.torch_dtype)
             effective_nodes_local = torch.zeros(1, dtype=self.torch_dtype)
-            effective_nodes = n_nodes_local
+            effective_nodes = torch.tensor(n_nodes_local, dtype=self.torch_dtype)
 
         self.data_reduced.n_nodes_local = torch.tensor(n_nodes_local, dtype=torch.int64)
         self.data_reduced.n_nodes_halo = torch.tensor(n_nodes_halo, dtype=torch.int64)


### PR DESCRIPTION
This PR fixes a runtime error that occurs when running with `consistency=False` and `halo_swap_mode=none`. The issue was caused by `effective_nodes` being assigned as a Python int during `setup_halo`, while training expected it to be a tensor and call `.to(self.device)` on it.

### Error
```
Error executing job with overrides: ['device_skip=0', 'precision=bf16', 'phase1_steps=300', 'hidden_channels=256', 'n_mlp_hidden_layers=2', 'n_messagePassing_layers=8', 'backend=xccl', 'halo_swap_mode=none', 'consistency=False', 'online=True', 'client.backend=adios', 'client.adios_transport=RDMA', 'online_update_freq=10', 'time_dependency=time_dependent', 'verbose=True', 'master_addr=x4208c0s5b0n0.hsn.cm.aurora.alcf.anl.gov']
Traceback (most recent call last):
  File "/flare/insitu/matheuscosta/nekrs/3rd_party/dist-gnn/main.py", line 226, in main
    train(cfg, client)
  File "/flare/insitu/matheuscosta/nekrs/3rd_party/dist-gnn/main.py", line 86, in train
    loss = trainer.train_step(data)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/lus/flare/projects/insitu/matheuscosta/nekrs/3rd_party/dist-gnn/trainer.py", line 1374, in train_step
    graph.effective_nodes = graph.effective_nodes.to(self.device)
                            ^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'int' object has no attribute 'to'
```

### Fix

 `effective_nodes = n_nodes_local` to `effective_nodes = torch.tensor(n_nodes_local, dtype=self.torch_dtype)`
