### PR TITLE
Changes to setup_case and template changes for turbChannel_srgnn example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ logfile
 
 # ML related items
 __pycache__/
-_env/
+_env*/
 
 # SmartSim/SmartRedis outputs
 SmartSim/

--- a/examples/turbChannel_srgnn/README.md
+++ b/examples/turbChannel_srgnn/README.md
@@ -33,7 +33,7 @@ The HPC systems currently supported are for this example are:
 * [Polaris](https://docs.alcf.anl.gov/polaris/) (Argonne LCF)
 * [Aurora](https://docs.alcf.anl.gov/aurora/) (Argonne LCF)
 
-For example, to build nekRS-ML on Aurora, execute from a compute node
+For example, to build nekRS-ML on Aurora, from the login nodes execute 
 
 ```sh
 ./BuildMeOnAurora
@@ -44,25 +44,25 @@ For example, to build nekRS-ML on Aurora, execute from a compute node
 Scripts are provided to conveniently generate run scripts and config files for the workflow on the different ALCF systems.
 Note that a virtual environment with PyTorch Geometric and other dependencies is needed to train the SR-GNN.
 
-**From a compute node** execute
+From a login node execute
 
 ```sh
-./gen_run_script <system_name> </path/to/nekRS>
+./gen_run_script <system_name> </path/to/nekRS> -n <number_of_nodes>
 ```
 
-or
+where `-n <number_of_nodes>` is needed to specify the number of nodes to run on. 
 
+The script will produce a `run.sh` script specifically tailored to the desired system and using the desired nekRS install directory. **NOTE**: you will need to change the project name in the run script before submission.
+
+The `gen_run_script` takes a number of arguments, to see the list run 
 ```sh
-./gen_run_script <system_name> </path/to/nekRS> -v </path/to/venv>
+./gen_run_script <system_name> </path/to/nekRS> -h
 ```
-if you have the necessary packages already installed in a Python virtual environment.
 
-The script will produce a `run.sh` script specifically tailored to the desired system and using the desired nekRS install directory.
-
-Finally, simply execute the run script **from the compute nodes** with
+Finally, simply submit the run script for execution on the desired system
 
 ```bash
-./run.sh
+qsub run.sh
 ```
 
 The `run.sh` script is composed of five steps:

--- a/examples/turbChannel_srgnn/nrsrun_aurora
+++ b/examples/turbChannel_srgnn/nrsrun_aurora
@@ -22,9 +22,19 @@ chk_case $TOTAL_RANKS
 #--------------------------------------
 # Generate the run script
 RFILE=run.sh
-echo "#!/bin/bash" > $RFILE
+echo "#!/bin/bash -l" > $RFILE
+echo "#PBS -S /bin/bash" >> $RFILE
+echo "#PBS -N nekrs-ml" >> $RFILE
+echo "#PBS -l select=1" >> $RFILE
+echo "#PBS -l walltime=00:30:00" >> $RFILE
+echo "#PBS -l filesystems=home:flare" >> $RFILE
+echo "#PBS -A <project_name>" >> $RFILE
+echo "#PBS -q debug" >> $RFILE
+echo "#PBS -k doe" >> $RFILE
+echo "#PBS -j oe" >> $RFILE
+echo "cd $PBS_O_WORKDIR" >> $RFILE
 
-echo "export TZ='/usr/share/zoneinfo/US/Central'" >> $RFILE
+echo -e "\nexport TZ='/usr/share/zoneinfo/US/Central'" >> $RFILE
 
 echo -e "\necho Jobid: \$PBS_JOBID" >>$RFILE
 echo "echo Running on host \`hostname\`" >>$RFILE

--- a/examples/turbChannel_srgnn/nrsrun_polaris
+++ b/examples/turbChannel_srgnn/nrsrun_polaris
@@ -19,9 +19,19 @@ chk_case $TOTAL_RANKS
 #--------------------------------------
 # Generate the run script
 RFILE=run.sh
-echo "#!/bin/bash" > $RFILE
+echo "#!/bin/bash -l" > $RFILE
+echo "#PBS -S /bin/bash" >> $RFILE
+echo "#PBS -N nekrs-ml" >> $RFILE
+echo "#PBS -l select=1" >> $RFILE
+echo "#PBS -l walltime=00:30:00" >> $RFILE
+echo "#PBS -l filesystems=home:eagle" >> $RFILE
+echo "#PBS -A <project_name>" >> $RFILE
+echo "#PBS -q debug" >> $RFILE
+echo "#PBS -k doe" >> $RFILE
+echo "#PBS -j oe" >> $RFILE
+echo "cd $PBS_O_WORKDIR" >> $RFILE
 
-echo "export TZ='/usr/share/zoneinfo/US/Central'" >> $RFILE
+echo -e "\nexport TZ='/usr/share/zoneinfo/US/Central'" >> $RFILE
 
 echo -e "\necho Jobid: \$PBS_JOBID" >>$RFILE
 echo "echo Running on host \`hostname\`" >>$RFILE

--- a/scripts/ml/setup_case
+++ b/scripts/ml/setup_case
@@ -5,7 +5,7 @@ set -a
 SYSTEM=
 NEKRS_HOME=
 VENV_PATH="${PWD}/../_env"
-NODES=$(cat ${PBS_NODEFILE} | wc -l)
+NODES=
 TIME="01:00"
 PROJ_ID="datascience"
 DEPLOYMENT="offline"
@@ -96,12 +96,23 @@ function parse_args() {
     esac
   done
 
+  # If nodes was not set, check if available from interactive session PBVS env
+  if [ -z "${NODES}" ]; then
+    if [ ! -z "${PBS_NODEFILE}" ]; then
+      NODES=$(cat ${PBS_NODEFILE} | wc -l)
+    fi
+  fi
+
   # Append model and client to VENV_PATH as what is installed in the environment
   # depends on the model and the client.
   VENV_PATH=${VENV_PATH}_${MODEL}_${CLIENT}
 }
 
 function check_args() {
+  if [ -z "${NODES}" ]; then
+    echo "Number of nodes was not specified, use --nodes or -n to specify the nodes or run from an interactive session"
+    exit 1
+  fi
   if [ ${SYSTEM} != "aurora" ] && [ ${SYSTEM} != "polaris" ] && [ ${SYSTEM} != "crux" ]; then
     echo "Invalid system name! Supported systems are aurora, polaris and crux."
     exit 1

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -88,7 +88,7 @@ class TGVOnline(NekRSMLOnlineTest):
             rpn=self.ranks_per_node,
             time_dependency="time_independent",
             client="smartredis",
-            target_loss=1.6206e-04,
+            target_loss=2.706e-04,
         )
         self.tags |= {"tgv_online"}
 


### PR DESCRIPTION
Add ability to setup the examples both from login nodes and compute nodes, whereas before an interactive session on the compute nodes was required.

The PR also makes changes to the examples such that `run.sh` can be submitted to the queue.

To Do

- [x] Need to make sure this does not impact Reframe testing.